### PR TITLE
chore: bump version to 0.1.2 and clean imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,14 +779,13 @@ checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "vortex-protocol"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytes",
  "chrono",
  "criterion",
  "proptest",
  "rand 0.8.5",
- "serde",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vortex-protocol"
-version = "0.1.1"
+version = "0.1.2"
 description = "A P2P file transfer protocol"
 authors = ["The Dragonfly Developers"]
 homepage = "https://d7y.io/"
@@ -14,7 +14,6 @@ edition = "2021"
 thiserror = "2.0"
 rand = "0.8"
 bytes = "1"
-serde = { version = "1.0", features = ["derive"] }
 chrono = { version = "0.4.41", features = ["serde", "clock"] }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,6 @@
 use crate::error::{Error, Result};
 use bytes::{BufMut, Bytes, BytesMut};
 use rand::prelude::*;
-use serde::{Deserialize, Serialize};
 
 pub mod error;
 pub mod tlv;
@@ -30,7 +29,7 @@ pub const HEADER_SIZE: usize = 6;
 const MAX_VALUE_SIZE: usize = 4 * 1024 * 1024 * 1024;
 
 /// Header represents the Vortex packet header.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Header {
     id: u8,
     tag: tlv::Tag,

--- a/src/tlv/mod.rs
+++ b/src/tlv/mod.rs
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-use serde::{Deserialize, Serialize};
-
 pub mod close;
 pub mod download_piece;
 pub mod error;
@@ -23,7 +21,7 @@ pub mod piece_content;
 
 /// Tag Definitions
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tag {
     /// Download the content of a piece from a peer. It is composed of `{Task ID}-{Piece ID}`,
     /// where the Task ID is a 32-byte SHA-256 value and the Piece ID is a number.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request makes minor adjustments to the `vortex-protocol` crate, primarily removing the `serde` dependency and related derive macros from the codebase. The changes simplify the code and reduce dependencies, but do not affect core functionality.

Dependency and serialization changes:

* Removed the `serde` dependency from `Cargo.toml` and eliminated all `Serialize` and `Deserialize` derives from the `Header` struct in `src/lib.rs` and the `Tag` enum in `src/tlv/mod.rs`. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L17) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L20) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L33-R32) [[4]](diffhunk://#diff-b3ae0acc1fc8725ee94e30781b36f2004883893c69ca19141509709dbb86db99L17-R24)

Miscellaneous:

* Bumped the crate version from `0.1.1` to `0.1.2` in `Cargo.toml`.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
