### PR TITLE
Fix spelling: `an`

### DIFF
--- a/src/tlv/error.rs
+++ b/src/tlv/error.rs
@@ -20,7 +20,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 /// CODE_SIZE is the size of the error code in bytes.
 const CODE_SIZE: usize = 1;
 
-/// Code represents a error code.
+/// Code represents an error code.
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Code {
@@ -70,7 +70,7 @@ impl From<Code> for u8 {
     }
 }
 
-/// Error represents a error request.
+/// Error represents an error request.
 ///
 /// Value Format:
 ///  - Error Code (1 bytes): Error code.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Use `an` instead of `a`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
