### PR TITLE
fix: correct length field size, reserved tag range, and flaky test assertion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ scalable file sharing capabilities.
 - **Cache Piece Content (Tag=0x07):** Raw cache piece data or cache piece fragments.
 - **Error (Tag=0xFF):** Conveys error.
 - **Close (Tag=0xFE):** Indicates the end of a connection.
-- **Reserved Tags:** Tags 6-253 may be allocated for metadata, compression, encryption, or future protocol extensions.
+- **Reserved Tags:** Tags 8-253 may be allocated for metadata, compression, encryption, or future protocol extensions.
 
 ## Example
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,15 +229,15 @@ impl From<Header> for Bytes {
 /// Packet Format:
 ///     - Packet Identifier (1 bytes): Uniquely identifies each packet
 ///     - Tag (1 bytes): Specifies data type in value field
-///     - Length (8 bytes): Indicates Value field length, up to 4 GiB
-///     - Value (variable): Actual data content, maximum 1 GiB
+///     - Length (4 bytes): Indicates Value field length, up to 4 GiB
+///     - Value (variable): Actual data content, maximum 4 GiB
 ///
 /// Protocol Format:
 ///
 /// ```text
 /// ---------------------------------------------------------------------------------------------------
 /// |                             |                    |                    |                         |
-/// | Packet Identifier (1 bytes) |    Tag (1 bytes)   |  Length (8 bytes)  |   Value (up to 4 GiB)   |
+/// | Packet Identifier (1 bytes) |    Tag (1 bytes)   |  Length (4 bytes)  |   Value (up to 4 GiB)   |
 /// |                             |                    |                    |                         |
 /// ---------------------------------------------------------------------------------------------------
 /// ```
@@ -374,7 +374,7 @@ impl TryFrom<Bytes> for Vortex {
     }
 }
 
-/// Implement From<PieceContent> for Bytes.
+/// Implement From<Vortex> for Bytes.
 impl From<Vortex> for Bytes {
     /// from converts a Vortex packet to Bytes.
     fn from(packet: Vortex) -> Self {
@@ -471,7 +471,6 @@ mod tests {
 
         assert_eq!(header.tag, tag);
         assert_eq!(header.length, value_length);
-        assert!(header.id <= 254);
     }
 
     #[test]

--- a/src/tlv/mod.rs
+++ b/src/tlv/mod.rs
@@ -57,7 +57,7 @@ pub enum Tag {
     /// The content of a cache piece, with a maximum size of 4 GiB per piece.
     CachePieceContent = 7,
 
-    /// Reserved for future use, for tags 6-254.
+    /// Reserved for future use, for tags 8-253.
     Reserved(u8),
 
     /// Close the connection. If server or client receives this tag, it will close the connection.


### PR DESCRIPTION
## Description

Few small inaccuracies found while reading the code:

- `Vortex` doc comment says Length field is 8 bytes, but it's `put_u32` (4 bytes). Same comment says max value is 1 GiB but `MAX_VALUE_SIZE` is 4 GiB.
- `From<Vortex> for Bytes` impl has a copy-paste comment saying `From<PieceContent>`.
- `test_header_new` asserts `header.id <= 254`, but `rng.gen::<u8>()` produces 0-255, so it fails ~1/256 runs when `id == 255`.
- `Reserved` tag comment says "for tags 6-254", correct range is 8-253 (6 and 7 are defined, 254 is `Close`). Same issue in `docs/README.md`.

## Related Issue

No open issue - doc/comment/test fixes only.

## Motivation and Context

Flaky test repro: run `cargo test tests::test_header_new` repeatedly, panics when `id == 255`.