### PR TITLE
build: update rust toolchain from 1.85.0 to 1.88.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Rust cache 
+      - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
@@ -27,7 +27,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-          toolchain: 1.85.0
+          toolchain: 1.88.0
 
       - name: Set up Clang
         uses: egor-tensin/setup-clang@v1

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -3,4 +3,4 @@ MD010: false
 MD013: false
 
 MD046:
-  style: "fenced"
+  style: 'fenced'

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.88.0"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This pull request updates the project's Rust toolchain version from 1.85.0 to 1.88.0 and makes a minor style change in the markdown linting configuration.

Toolchain updates:

* Updated the Rust toolchain version to 1.88.0 in both the `rust-toolchain.toml` file and the GitHub Actions workflow configuration (`.github/workflows/lint.yml`). [[1]](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL2-R2) [[2]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L30-R30)

Configuration style:

* Changed the quote style for the `MD046` rule in `.markdownlint.yml` from double to single quotes for consistency.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Screenshots (if appropriate)
